### PR TITLE
internal/ctl: Enable scanning of printed lists

### DIFF
--- a/internal/ctl/helpers.go
+++ b/internal/ctl/helpers.go
@@ -61,52 +61,54 @@ func printEntity(entity *pb.Entity, fields string) {
 		}
 	}
 
+	startChar := ""
 	for _, f := range fieldList {
 		switch strings.ToLower(f) {
 		case "id":
-			fmt.Printf("ID: %s\n", entity.GetID())
+			fmt.Printf("%sID: %s\n", startChar, entity.GetID())
 		case "number":
-			fmt.Printf("Number: %d\n", entity.GetNumber())
+			fmt.Printf("%sNumber: %d\n", startChar, entity.GetNumber())
 		case "primarygroup":
 			if entity.Meta != nil && entity.GetMeta().GetPrimaryGroup() != "" {
-				fmt.Printf("Primary Group: %s\n", entity.GetMeta().GetPrimaryGroup())
+				fmt.Printf("%sPrimary Group: %s\n", startChar, entity.GetMeta().GetPrimaryGroup())
 			}
 		case "gecos":
 			if entity.Meta != nil && entity.GetMeta().GetGECOS() != "" {
-				fmt.Printf("GECOS: %s\n", entity.GetMeta().GetGECOS())
+				fmt.Printf("%sGECOS: %s\n", startChar, entity.GetMeta().GetGECOS())
 			}
 		case "legalname":
 			if entity.Meta != nil && entity.GetMeta().GetLegalName() != "" {
-				fmt.Printf("legalName: %s\n", entity.GetMeta().GetLegalName())
+				fmt.Printf("%slegalName: %s\n", startChar, entity.GetMeta().GetLegalName())
 			}
 		case "displayname":
 			if entity.Meta != nil && entity.Meta.GetDisplayName() != "" {
-				fmt.Printf("displayname: %s\n", entity.GetMeta().GetDisplayName())
+				fmt.Printf("%sdisplayname: %s\n", startChar, entity.GetMeta().GetDisplayName())
 			}
 		case "homedir":
 			if entity.Meta != nil && entity.GetMeta().GetHome() != "" {
-				fmt.Printf("homedir: %s\n", entity.GetMeta().GetHome())
+				fmt.Printf("%shomedir: %s\n", startChar, entity.GetMeta().GetHome())
 			}
 		case "shell":
 			if entity.Meta != nil && entity.GetMeta().GetShell() != "" {
-				fmt.Printf("shell: %s\n", entity.GetMeta().GetShell())
+				fmt.Printf("%sshell: %s\n", startChar, entity.GetMeta().GetShell())
 			}
 		case "graphicalshell":
 			if entity.Meta != nil && entity.GetMeta().GetGraphicalShell() != "" {
-				fmt.Printf("graphicalShell: %s\n", entity.GetMeta().GetGraphicalShell())
+				fmt.Printf("%sgraphicalShell: %s\n", startChar, entity.GetMeta().GetGraphicalShell())
 			}
 		case "badgenumber":
 			if entity.Meta != nil && entity.GetMeta().GetBadgeNumber() != "" {
-				fmt.Printf("badgeNumber: %s\n", entity.GetMeta().GetBadgeNumber())
+				fmt.Printf("%sbadgeNumber: %s\n", startChar, entity.GetMeta().GetBadgeNumber())
 			}
 		case "capabilities":
 			if entity.Meta != nil && len(entity.GetMeta().GetCapabilities()) != 0 {
-				fmt.Printf("Capabilities (Direct):\n")
+				fmt.Printf("%sCapabilities (Direct):\n", startChar)
 				for i := range entity.GetMeta().GetCapabilities() {
-					fmt.Printf("  - %s\n", entity.GetMeta().GetCapabilities()[i])
+					fmt.Printf("%s  - %s\n", startChar, entity.GetMeta().GetCapabilities()[i])
 				}
 			}
 		}
+		startChar = "  "
 	}
 }
 
@@ -126,30 +128,32 @@ func printGroup(group *pb.Group, fields string) {
 		}
 	}
 
+	startChar := ""
 	for _, f := range fieldList {
 		switch strings.ToLower(f) {
 		case "name":
-			fmt.Printf("Name: %s\n", group.GetName())
+			fmt.Printf("%sName: %s\n", startChar, group.GetName())
 		case "displayname":
-			fmt.Printf("Display Name: %s\n", group.GetDisplayName())
+			fmt.Printf("%sDisplay Name: %s\n", startChar, group.GetDisplayName())
 		case "number":
-			fmt.Printf("Number: %d\n", group.GetNumber())
+			fmt.Printf("%sNumber: %d\n", startChar, group.GetNumber())
 		case "managedby":
 			if group.GetManagedBy() == "" {
 				continue
 			}
-			fmt.Printf("Managed By: %s\n", group.GetManagedBy())
+			fmt.Printf("%sManaged By: %s\n", startChar, group.GetManagedBy())
 		case "expansions":
 			for _, exp := range group.GetExpansions() {
-				fmt.Printf("Expansion: %s\n", exp)
+				fmt.Printf("%sExpansion: %s\n", startChar, exp)
 			}
 		case "capabilities":
 			if len(group.GetCapabilities()) != 0 {
-				fmt.Printf("Capabilities:\n")
+				fmt.Printf("%sCapabilities:\n", startChar)
 				for i := range group.GetCapabilities() {
-					fmt.Printf("  - %s\n", group.GetCapabilities()[i])
+					fmt.Printf("%s  - %s\n", startChar, group.GetCapabilities()[i])
 				}
 			}
 		}
+		startChar = "  "
 	}
 }


### PR DESCRIPTION
Due to the unordered or flexible nature of fields, we can't pick some
value as a key, so instead print the lists as a regular yaml list. This
makes it possible for a person to visually scan from one group to
another without difficulty.

As an extra bonus, this means printed items are valid yaml, partly
because yaml keys can have spaces.