### PR TITLE
internal/ctl/system-ctl: don't run initialize(), rename to system-cli

### DIFF
--- a/internal/ctl/system-cli.go
+++ b/internal/ctl/system-cli.go
@@ -8,9 +8,12 @@ var (
 	cliCmd = &cobra.Command{
 		Use:   "cli",
 		Short: "Extra utilities for the CLI",
+		PersistentPreRun: cli_initialize,
 	}
 )
 
 func init() {
 	systemCmd.AddCommand(cliCmd)
 }
+
+func cli_initialize(*cobra.Command, []string) {}


### PR DESCRIPTION
the default initialize() is not necessary when generating completions and docs, so we can override it with an empty function.

Also, the file was renamed to `system-cli` to put it more inline with other files' naming conventions.
