### PR TITLE
internal/ctl/root.go: only set the default entity if no error

### DIFF
--- a/internal/ctl/root.go
+++ b/internal/ctl/root.go
@@ -67,8 +67,9 @@ func onInit() {
 	user, err := user.Current()
 	if err != nil {
 		fmt.Println("Could not get default user:", err)
+	} else {
+		viper.SetDefault("entity", user.Username)
 	}
-	viper.SetDefault("entity", user.Username)
 }
 
 // Execute serves as the entrypoint to the ctl package.


### PR DESCRIPTION
when using qemu-user-static to run netauth in the xbps-src chroot on cross (for generating completions/manpages), netauth segfaults because it tries to access a field in a nil value after `user.Current()` errors. This patch makes it so that the field is only accessed when it exists.
