### PR TITLE
internal/rpc2/group: return ErrExists in GroupKVAdd if the key exists

### DIFF
--- a/internal/rpc2/group.go
+++ b/internal/rpc2/group.go
@@ -231,6 +231,15 @@ func (s *Server) GroupKVAdd(ctx context.Context, r *pb.KV2Request) (*pb.Empty, e
 			"client", getClientName(ctx),
 		)
 		return &pb.Empty{}, ErrDoesNotExist
+	case tree.ErrKeyExists:
+		s.log.Warn("Error Updating Group",
+			"entity", r.GetTarget(),
+			"authority", getTokenClaims(ctx).EntityID,
+			"service", getServiceName(ctx),
+			"client", getClientName(ctx),
+			"error", err,
+		)
+		return &pb.Empty{}, ErrExists
 	case nil:
 		s.log.Info("Group KV Updated Dumped",
 			"group", r.GetTarget(),

--- a/internal/rpc2/group_test.go
+++ b/internal/rpc2/group_test.go
@@ -433,6 +433,17 @@ func TestGroupKVAdd(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			ro:  false,
+			ctx: PrivilegedContext,
+			req: &pb.KV2Request{
+				Target: proto.String("group1"),
+				Data: &types.KVData{
+					Key: proto.String("key1"),
+				},
+			},
+			wantErr: ErrExists,
+		},
+		{
 			ro:      false,
 			ctx:     UnprivilegedContext,
 			req:     &pb.KV2Request{Target: proto.String("group1")},


### PR DESCRIPTION
previously it would fall back to the default case, `ErrInternal`
